### PR TITLE
Add view to view copying functions

### DIFF
--- a/src/main/helins/binf.cljc
+++ b/src/main/helins/binf.cljc
@@ -947,13 +947,15 @@
 (defmethod binf.protocol/copy-view [::binf.protocol/has-backing-buffer ::binf.protocol/has-backing-buffer]
   [dest-view dest-offset dest-absolute? src-view src-offset src-absolute? n-byte]
   (let [dest-bb (backing-buffer dest-view)
+        dest-bb-offset (buffer-offset dest-view)
         src-bb (backing-buffer src-view)
+        src-bb-offset (buffer-offset src-view)
         src-offset (if src-absolute? src-offset (position src-view))
         dest-offset (if dest-absolute? dest-offset (position dest-view))]
     (binf.buffer/copy dest-bb
-                      dest-offset
+                      (+ dest-bb-offset dest-offset)
                       src-bb
-                      src-offset
+                      (+ src-bb-offset src-offset)
                       n-byte)
     (when-not dest-absolute?
       (skip dest-view n-byte))

--- a/src/main/helins/binf/protocol.cljc
+++ b/src/main/helins/binf/protocol.cljc
@@ -184,6 +184,12 @@
         [viewable offset n-byte]))
 
 
+
+(defmulti copy-view (fn [dest-view dest-offset dest-absolute? src-view src-offset src-absolute? n-byte]
+                      [(type dest-view) (type src-view)]))
+
+
+
 ;;;;;;;;;; Hidden
 
 

--- a/src/main/helins/binf/protocol/impl.clj
+++ b/src/main/helins/binf/protocol/impl.clj
@@ -450,3 +450,23 @@
                             offset
                             n-byte)
            .slice))))
+
+(defmethod binf.protocol/copy-view [ByteBuffer ByteBuffer]
+  [dest-view dest-offset dest-absolute? src-view src-offset src-absolute? n-byte]
+  (let [dest-position-cache (.position dest-view)
+        src-position-cache (.position src-view)
+        src-limit-cache (.limit src-view)
+        new-limit (if src-absolute?
+                    (+ n-byte src-offset)
+                    (+ n-byte (.position src-view)))]
+    (when dest-absolute?
+      (.position dest-view dest-offset))
+    (when src-absolute?
+      (.position src-view src-offset))
+    (.limit src-view new-limit)
+    (.put dest-view src-view)
+    (when dest-absolute?
+      (.position dest-view dest-position-cache))
+    (when src-absolute?
+      (.position src-view src-position-cache))
+    (.limit src-view src-limit-cache)))

--- a/src/main/helins/binf/protocol/impl.cljs
+++ b/src/main/helins/binf/protocol/impl.cljs
@@ -541,6 +541,9 @@
                    this))))
 
 
+(derive js/DataView ::binf.protocol/has-backing-buffer)
+
+
 ;;;;;;;;;;
 
 

--- a/src/test/helins/binf/test.cljc
+++ b/src/test/helins/binf/test.cljc
@@ -803,6 +803,31 @@
     (t/is (= 12 (binf/position src-v)))
     (t/is (= 8 (binf/position dest-v))))
 
+  ;; With an offset view
+
+  (let [src-v (alloc-view 16)
+        dest-v (-> (binf.buffer/alloc 64)
+                   (binf/view 32 16)
+                   (binf/endian-set :little-endian))]
+
+    (doseq [i (range 16)]
+      (binf/wa-b8 src-v i i))
+
+    (binf/skip dest-v 4)
+    (binf/skip src-v 8)
+
+    (binf/wr-rr-view dest-v src-v 4)
+
+    (doseq [i (range 4)]
+      (t/is (= 0 (binf/ra-i8 dest-v i))))
+    (doseq [i (range 4 8)]
+      (t/is (= (+ i 4) (binf/ra-i8 dest-v i))))
+    (doseq [i (range 8 16)]
+      (t/is (= 0 (binf/ra-i8 dest-v i))))
+
+    (t/is (= 12 (binf/position src-v)))
+    (t/is (= 8 (binf/position dest-v))))
+
   ;; Read relative -> Write absolute
 
   ;; Full copy


### PR DESCRIPTION
## Rationale

I have hit a few scenarios where I want to copy bytes from one view to another. It feels natural for this to be part of the main `binf` namespace. The alternative is to do something like `ra-buffer` followed by `wa-buffer`. But it is nice to just copy directly between the views when possible rather than going via an intermediate buffer. 

## Example + boilerplate

```clj
(let [src-v (-> (binf.buffer/alloc 16)
                binf/view
                (binf/endian-set :little-endian))
      dest-v (-> (binf.buffer/alloc 16)
                 binf/view
                 (binf/endian-set :little-endian))]

  (doseq [i (range 16)]
    (binf/wa-b8 src-v i i))

  ;; The actual view copy
  (binf/wa-ra-view dest-v 0 src-v 0 16)

  (doseq [i (range 16)]
    (t/is (= i (binf/ra-i8 dest-v i))))

  (t/is (= 0 (binf/position src-v)))
  (t/is (= 0 (binf/position dest-v))))
```

## What is added

Various functions named in format `wx-rx-view` where the `x` is `a` for absolute or `r` for relative.

Arguments are in dest, src order since there is some precedence in existing buffer copy function.

All functions call a new multimethod `helins.binf.protocol/copy-view`.

## Notes on the multimethod

There is a specialized implementation for java ByteBuffer -> ByteBuffer that uses `.put`.

There is a specialized implementation for backing buffer -> backing buffer which is the path used by js/DataView.

Then there is a default implementation that allocates an intermediate buffer that will work for anything that implement the relevant binf protocols.

The default implementation is not hit in the tests since the specialized versions are used instead. It can be verified that it works for both clojure/script by commenting out the specialized implementations then running the tests.

## Notes and Caveats

- No alteration of anything existing. Only additions
- Not done any perf testing
- Fallback multimethod implementation will allocate a buffer the size of the required copy. It may be better to chunk it by default to avoid a potentially massive allocation