### PR TITLE
Fixing issues with absolute read/writes on offset views

### DIFF
--- a/src/main/helins/binf/protocol/impl.clj
+++ b/src/main/helins/binf/protocol/impl.clj
@@ -67,8 +67,7 @@
   binf.protocol/-IByteBuffer
 
     (-array-index [this position]
-      (+ (.arrayOffset this)
-         position))
+      position)
 
 
   binf.protocol/IAbsoluteReader

--- a/src/test/helins/binf/test.cljc
+++ b/src/test/helins/binf/test.cljc
@@ -53,6 +53,13 @@
                   (binf/endian-set :little-endian))))
 
 
+(t/deftest offset-view
+  (let [view (-> (binf.buffer/alloc 64)
+                 (binf/view 32 16)
+                 (binf/endian-set :little-endian))]
+    (binf/wa-b8 view 0 42)
+    (t/is (= 42 (binf/ra-u8 view 0)))))
+
 
 (t/deftest buffer->view
 


### PR DESCRIPTION
Fixes #3 

This just makes the impl of `binf.protocol/-IByteBuffer` for `ByteBuffer` the same as the existing impl for `DirectByteBuffer`.  I am not quite seeing what addition of the `.arrayOffset` was doing for things but I may well be missing something!

With this change I think many uses of `(binf.protocol/-array-index this position)` can just be replaced with `position`.