### PR TITLE
Read/write clojure data structures from/to a view

### DIFF
--- a/src/main/helins/binf/cabi.cljc
+++ b/src/main/helins/binf/cabi.cljc
@@ -45,7 +45,10 @@
   {:author "Adam Helinski"}
 
   (:refer-clojure :exclude [array
-                            struct]))
+                            vector
+                            struct])
+
+  (:require [helins.binf :as binf]))
 
 
 (declare force-env)
@@ -337,18 +340,49 @@
   "Given a description function for a type and a number of elements, returns a description function
    for an array."
 
-  [description-fn n-element]
+  ([description-fn n-element] (array description-fn n-element nil))
 
-  (fn def-array [env]
-    (let [{:as             element-2
-           :binf.cabi/keys [align
-                            n-byte]} (description-fn env)]
-      {:binf.cabi/align           align
-       :binf.cabi/n-byte          (* n-element
-                                     n-byte)
-       :binf.cabi/type            :array
-       :binf.cabi.array/element   element-2
-       :binf.cabi.array/n-element n-element})))
+  ([description-fn n-element align-override]
+
+   (fn def-array [env]
+     (let [{:as             element-2
+            :binf.cabi/keys [align
+                             n-byte]} (description-fn env)
+           final-align (or align-override align)]
+       {:binf.cabi/align           final-align
+        :binf.cabi/n-byte          (* n-element
+                                      (aligned final-align n-byte))
+        :binf.cabi/type            :array
+        :binf.cabi.array/element   element-2
+        :binf.cabi.array/n-element n-element}))))
+
+
+(defn vector
+
+  "Given a type name, a description function for a type and a number of elements, returns a
+   description function for a vector.
+
+   ```clojure
+   (def make-vec3
+        (vector :vec3 f32 3 16))
+   ```"
+
+  ([type description-fn n-element] (vector type description-fn n-element nil))
+
+  ([type description-fn n-element stride]
+
+   (fn def-vector [env]
+     (let [{:as             element-2
+            :binf.cabi/keys [align
+                             n-byte]} (description-fn env)
+           final-align (or stride align)]
+       {:binf.cabi/align           final-align
+        :binf.cabi/n-byte          (* n-element
+                                      n-byte)
+        :binf.cabi/type            :array
+        :binf.cabi.vector/type     type
+        :binf.cabi.array/element   element-2
+        :binf.cabi.array/n-element n-element}))))
 
 
 ;;;;;;;;;;
@@ -376,7 +410,7 @@
 
   [type constant+]
 
-  (fn def-struct [env]
+  (fn def-enum [env]
     (loop [constant-2+ constant+
            max-value   0
            tag->value  {}
@@ -436,7 +470,9 @@
   [type member+]
 
   (fn def-struct [env]
-    (loop [align        1
+    (loop [align        (if (:binf.cabi/gpu? env) ;; TODO: find a way to avoid this `gpu?` switch.
+                          (:binf.cabi/align env 1)
+                          1)
            layout       []
            member-2+    member+
            name->member {}
@@ -503,3 +539,290 @@
          :binf.cabi/type          :union
          :binf.cabi.union/member+ name->member
          :binf.cabi.union/type    type}))))
+
+(defn wr-cabi
+
+  "Writes a clojure data structure to the current position by some `layout`."
+
+  [view layout data]
+
+  (case (:binf.cabi/type layout)
+
+    :ptr
+    (throw (ex-info "Not implemented: writing pointers" {}))
+
+    :bool
+    (if (some? data)
+      (binf/wr-bool view data)
+      (binf/skip view 1))
+
+    :i8
+    (if (some? data)
+      (binf/wr-b8 view data)
+      (binf/skip view 1))
+
+    :i16
+    (if (some? data)
+      (binf/wr-b16 view data)
+      (binf/skip view 2))
+
+    :i32
+    (if (some? data)
+      (binf/wr-b32 view data)
+      (binf/skip view 4))
+
+    :i64
+    (if (some? data)
+      (binf/wr-b64 view data)
+      (binf/skip view 8))
+
+    :u16
+    (if (some? data)
+      (binf/wr-b16 view data)
+      (binf/skip view 2))
+
+    :u32
+    (if (some? data)
+      (binf/wr-b32 view data)
+      (binf/skip view 4))
+
+    :u64
+    (if (some? data)
+      (binf/wr-b64 view data)
+      (binf/skip view 8))
+
+    :f32
+    (if (some? data)
+      (binf/wr-f32 view data)
+      (binf/skip view 4))
+
+    :f64
+    (if (some? data)
+      (binf/wr-f64 view data)
+      (binf/skip view 8))
+
+    :enum
+    (if (some? data)
+      (do
+        (assert (keyword? data))
+        (let [possibilities (:binf.cabi.enum/constant+ layout)
+              i (get possibilities data)]
+          (when-not (some? i)
+            (throw (ex-info (str "No " data " in enum " (:binf.cabi.enum/type layout)) (assoc layout :value data))))
+          (binf/wr-b32 view i)))
+      (binf/skip view 4))
+
+    :struct
+    (let [struct-layout (:binf.cabi.struct/layout layout)
+          members (:binf.cabi.struct/member+ layout)]
+      (loop [struct-layout struct-layout
+             prior-offset 0
+             prior-n-byte 0]
+        (if-let [mk (first struct-layout)]
+          (let [member (get members mk)
+                offset (:binf.cabi/offset member)
+                to-skip (- offset (+ prior-offset prior-n-byte))]
+            (when (< 0 to-skip)
+              (binf/skip view to-skip))
+            (wr-cabi view member (get data mk))
+            (recur (rest struct-layout) offset (:binf.cabi/n-byte member)))
+          (let [n-byte (:binf.cabi/n-byte layout)
+                to-skip (- n-byte (+ prior-offset prior-n-byte))]
+            (when (< 0 to-skip)
+              (binf/skip view to-skip))))))
+
+    :union
+    (if (some? data)
+      (let [[union-type union-data] (first data)
+            members (:binf.cabi.union/member+ layout)
+            union-layout (get members union-type)
+            to-skip (- (:binf.cabi/n-byte layout) (:binf.cabi/n-byte union-layout))]
+        (when-not (some? union-layout)
+          (throw (ex-info (str "No such " union-type " in union " (:binf.cabi.union/type layout)) {})))
+        (wr-cabi view union-layout union-data)
+        (when (< 0 to-skip)
+          (binf/skip view to-skip)))
+      (let [n-byte (- (:binf.cabi/n-byte layout) (:binf.cabi/n-byte layout))]
+        (binf/skip view n-byte)))
+
+    :alias
+    (wr-cabi view (:binf.cabi.alias/inner layout) data)
+
+    :array
+    (let [n-element (:binf.cabi.array/n-element layout)
+          element (:binf.cabi.array/element layout)
+          element-n-byte (:binf.cabi/n-byte element)
+          element-align (:binf.cabi/align element)
+          n-byte (:binf.cabi/n-byte layout)
+          element-padding (- (aligned element-align element-n-byte) element-n-byte)]
+      (loop [n-written 0
+             data data]
+        (if (seq data)
+          (if-let [d (first data)]
+            (do
+              (wr-cabi view element d)
+              (when (< 0 element-padding)
+                (binf/skip view element-padding))
+              (recur (inc n-written) (rest data)))
+            (let [align (:binf.cabi/align layout)
+                  to-skip (+ element-padding (aligned align element-n-byte))]
+              (binf/skip view to-skip)
+              (recur (inc n-written) (rest data))))
+          (let [to-skip (* (- n-element n-written) (aligned element-align element-n-byte))]
+            (when (< 0 to-skip)
+              (binf/skip view to-skip))))))))
+
+(defn wa-cabi
+
+  "Writes a clojure data structure to an absolute `position` by some `layout`."
+
+  [view position layout data]
+
+  (let [old-position (binf/position view)]
+    (binf/seek view position)
+    (wr-cabi view layout data)
+    (binf/seek view old-position)))
+
+
+(defn rr-cabi
+
+  "Reads a clojure data structure from the current position by some `layout`.
+
+   If unions are used a function `pick-union` can be supplied that decides which
+   union to use. It takes the union layout and the data read so far as arguments
+   and should return the key of the union type.
+
+   If `pick-union` is not supplied or returns null then it is not possible to
+   figure out which union to use so a byte buffer of the size of the union is
+   returned instead."
+
+  ([view layout] (rr-cabi view layout nil))
+
+  ([view layout {:keys [so-far pick-union] :as context}]
+
+   (case (:binf.cabi/type layout)
+
+     :ptr
+     (throw (ex-info "Not implemented: reading pointers" {}))
+
+     :struct
+     (let [struct-layout (:binf.cabi.struct/layout layout)
+           members (:binf.cabi.struct/member+ layout)
+           n-byte (:binf.cabi/n-byte layout)]
+       (loop [data {}
+              struct-layout struct-layout
+              prior-offset 0
+              prior-n-byte 0]
+         (if-let [mk (first struct-layout)]
+           (let [member (get members mk)
+                 _ (assert (some? member) (str "no " mk " in " members))
+                 offset (:binf.cabi/offset member)
+                 n-byte (:binf.cabi/n-byte member)
+                 to-skip (- offset (+ prior-offset prior-n-byte))]
+             (when (< 0 to-skip)
+               (binf/skip view to-skip))
+             (let [inner-data (rr-cabi view member (assoc context :so-far data))]
+               (recur (assoc data mk inner-data) (rest struct-layout) offset n-byte)))
+           (let [to-skip (- n-byte (+ prior-offset prior-n-byte))]
+             (when (< 0 to-skip)
+               (binf/skip view to-skip))
+             data))))
+
+     :union
+     (let [n-byte (:binf.cabi/n-byte layout)]
+       (cond
+         (some? pick-union)
+         (let [union-type (pick-union (:binf.cabi.union/type layout) so-far)]
+           (if (some? union-type)
+             (let [members (:binf.cabi.union/member+ layout)
+                   union-layout (get members union-type)
+                   to-skip (- n-byte (:binf.cabi/n-byte union-layout))]
+               (when-not (some? union-layout)
+                 (throw (ex-info (str "No such " union-type " in union " (:binf.cabi.union/type layout)) {})))
+               (let [union-data (rr-cabi view union-layout context)]
+                 (when (< 0 to-skip)
+                   (binf/skip view to-skip))
+                 (hash-map union-type union-data)))
+             (binf/rr-buffer view n-byte context)))
+
+         ;; TODO: maybe offer another way to figure out union?
+
+         :else
+         (binf/rr-buffer view n-byte context)))
+
+     :alias
+     (rr-cabi view (:binf.cabi.alias/inner layout) context)
+
+     :bool
+     (binf/rr-bool view)
+
+     :i8
+     (binf/rr-i8 view)
+
+     :i16
+     (binf/rr-i16 view)
+
+     :i32
+     (binf/rr-i32 view)
+
+     :i64
+     (binf/rr-i64 view)
+
+     :u8
+     (binf/rr-u8 view)
+
+     :u16
+     (binf/rr-u16 view)
+
+     :u32
+     (binf/rr-u32 view)
+
+     :u64
+     (binf/rr-u64 view)
+
+     :f32
+     (binf/rr-f32 view)
+
+     :f64
+     (binf/rr-f64 view)
+
+     :enum
+     (let [i (binf/rr-u32 view)
+           i->enum (->> (:binf.cabi.enum/constant+ layout)
+                        (map (fn [[i e]]
+                               [e i]))
+                        (into {}))
+           enum (get i->enum i)]
+       (when-not (some? enum)
+         (throw (ex-info (str "No " i " in enum " (:binf.cabi.enum/type layout)) (assoc layout :int i))))
+       enum)
+
+     :array
+     (let [n-element (:binf.cabi.array/n-element layout)
+           element (:binf.cabi.array/element layout)
+           element-n-byte (:binf.cabi/n-byte element)
+           element-align (:binf.cabi/align element)
+           to-skip (- (aligned element-align element-n-byte) element-n-byte)
+           data (loop [to-read (range n-element)
+                       data []]
+                  (if-let [_ (first to-read)]
+                    (let [d (rr-cabi view element context)]
+                      (when (< 0 to-skip)
+                        (binf/skip view to-skip))
+                      (recur (rest to-read) (conj data d)))
+                    data))]
+       data))))
+
+(defn ra-cabi
+
+  "Reads a clojure data structure from an absolute `position` by some `layout`."
+
+  ([view position layout] (ra-cabi view position layout nil))
+
+  ([view position layout context]
+
+   (let [old-position (binf/position view)]
+     (binf/seek view position)
+     (let [result (rr-cabi view layout context)]
+       (binf/seek view old-position)
+       result))))

--- a/src/main/helins/binf/cabi.cljc
+++ b/src/main/helins/binf/cabi.cljc
@@ -470,9 +470,7 @@
   [type member+]
 
   (fn def-struct [env]
-    (loop [align        (if (:binf.cabi/gpu? env) ;; TODO: find a way to avoid this `gpu?` switch.
-                          (:binf.cabi/align env 1)
-                          1)
+    (loop [align        1
            layout       []
            member-2+    member+
            name->member {}

--- a/src/test/helins/binf/test/cabi.cljc
+++ b/src/test/helins/binf/test/cabi.cljc
@@ -30,9 +30,6 @@
 (def env32
      (binf.cabi/env w32))
 
-(def env32-gpu
-     (assoc (binf.cabi/env w32) :binf.cab/gpu? true))
-
 (def env64
      (binf.cabi/env w64))
 
@@ -350,7 +347,7 @@
     (let [v (alloc-view)
           ivec3 (binf.cabi/vector :ivec3 binf.cabi/i32 3 16)
           array-length 5
-          layout ((binf.cabi/array ivec3 array-length) env32-gpu)
+          layout ((binf.cabi/array ivec3 array-length) env32)
           data (->> (range (* array-length 3))
                     (partition 3)
                     (mapv vec))
@@ -369,7 +366,7 @@
       (let [v (alloc-view)
             column (binf.cabi/vector :ivec4 binf.cabi/i32 4 16)
             matrix (binf.cabi/vector :mat4x4 column 4 64)
-            layout (matrix env32-gpu)
+            layout (matrix env32)
             matrix (->> (range 16) (partition 4) (mapv vec))
             e (->> matrix (mapcat identity) vec)]
         (binf.cabi/wr-cabi v layout matrix)
@@ -381,7 +378,7 @@
       (let [v (alloc-view)
             column (binf.cabi/vector :ivec4 binf.cabi/i32 2 8)
             matrix (binf.cabi/vector :mat3x2 column 3 24)
-            layout (matrix env32-gpu)
+            layout (matrix env32)
             matrix (->> (range (* 3 2)) (partition 2) (mapv vec))
             e (->> matrix (mapcat identity) vec)]
         (binf.cabi/wr-cabi v layout matrix)
@@ -393,7 +390,7 @@
       (let [v (alloc-view)
             column (binf.cabi/vector :ivec4 binf.cabi/i32 3 16)
             matrix (binf.cabi/vector :mat2x3 column 2 32)
-            layout (matrix env32-gpu)
+            layout (matrix env32)
             matrix (->> (range (* 3 2)) (partition 3) (mapv vec))
             e (->> matrix (mapcat #(conj % 0)) vec)]
         (binf.cabi/wr-cabi v layout matrix)
@@ -405,7 +402,7 @@
 
   (t/testing "Single primitive"
     (let [v (alloc-view)
-          layout (binf.cabi/i32 env32-gpu)
+          layout (binf.cabi/i32 env32)
           e 42]
       (binf.cabi/wr-cabi v layout e)
       (binf/seek v 0)
@@ -419,7 +416,7 @@
                                    [:c 1000]
                                    :d
                                    [:e 42]
-                                   :f]) env32-gpu)]
+                                   :f]) env32)]
 
       (let [v (alloc-view)
             e :a]
@@ -517,7 +514,7 @@
     (let [v (alloc-view)
           layout ((binf.cabi/struct :my-struct
                                     [[:a binf.cabi/i32]
-                                     [:b binf.cabi/i32]]) env32-gpu)
+                                     [:b binf.cabi/i32]]) env32)
           e {:a 10 :b 20}]
       (binf.cabi/wr-cabi v layout e)
       (binf/seek v 0)
@@ -528,7 +525,7 @@
       (let [v (alloc-view)
             layout ((binf.cabi/struct :my-struct
                                       [[:a binf.cabi/i32]
-                                       [:b binf.cabi/i32]]) env32-gpu)
+                                       [:b binf.cabi/i32]]) env32)
             data {:b 20}
             e (assoc data :a 0)]
         (binf.cabi/wr-cabi v layout data)
@@ -538,7 +535,7 @@
 
   (t/testing "Simple array"
     (let [v (alloc-view)
-          layout ((binf.cabi/array binf.cabi/i32 5) env32-gpu)
+          layout ((binf.cabi/array binf.cabi/i32 5) env32)
           e [1 2 3 4 5]]
       (binf.cabi/wr-cabi v layout e)
       (binf/seek v 0)
@@ -550,7 +547,7 @@
           inner (binf.cabi/struct :my-struct
                                   [[:a binf.cabi/i32]
                                    [:b binf.cabi/i32]])
-          layout ((binf.cabi/array inner 5) env32-gpu)
+          layout ((binf.cabi/array inner 5) env32)
           e (->> (range 10) (partition 2) (mapv (fn [[a b]] {:a a :b b})))]
       (binf.cabi/wr-cabi v layout e)
       (binf/seek v 0)
@@ -560,7 +557,7 @@
   (t/testing "Simple array of specially aligned arrays"
     (let [v (alloc-view)
           ivec3 (binf.cabi/vector :ivec3 binf.cabi/i32 3 16)
-          layout ((binf.cabi/array ivec3 5) env32-gpu)
+          layout ((binf.cabi/array ivec3 5) env32)
           e (->> (range 1 8)
                  (partition 3 1)
                  (mapv vec))]
@@ -574,7 +571,7 @@
           ivec3 (binf.cabi/vector :ivec3 binf.cabi/i32 3 16)
           layout ((binf.cabi/struct :my-struct
                                     [[:position ivec3]
-                                     [:normal ivec3]]) env32-gpu)
+                                     [:normal ivec3]]) env32)
           e {:position [3 4 5]
              :normal [10 11 12]}]
       (binf.cabi/wr-cabi v layout e)
@@ -586,7 +583,7 @@
           ivec3 (binf.cabi/vector :ivec3 binf.cabi/i32 3 16)
           layout ((binf.cabi/struct :my-struct
                                     [[:position ivec3]
-                                     [:normal ivec3]]) env32-gpu)
+                                     [:normal ivec3]]) env32)
           e {:position [3 4 5]
              :normal [10 11 12]}]
       (binf.cabi/wr-cabi v layout e)
@@ -604,7 +601,7 @@
                                     [[:count binf.cabi/i32]
                                      [:min ivec3]
                                      [:max ivec3]
-                                     [:vertices (binf.cabi/array vertex 2)]]) env32-gpu)
+                                     [:vertices (binf.cabi/array vertex 2)]]) env32)
           e {:count 2
              :min [1 2 3]
              :max [11 12 13]
@@ -636,7 +633,7 @@
                                        [:e struct-a]
                                        [:f ivec3]
                                        [:g (binf.cabi/array struct-a 3)]
-                                       [:h binf.cabi/i32]]) env32-gpu)
+                                       [:h binf.cabi/i32]]) env32)
           data {}
           e {:a [0 0],
              :b [0 0 0],
@@ -672,7 +669,7 @@
                                        [:e struct-a]
                                        [:f ivec3]
                                        [:g (binf.cabi/array struct-a 3)]
-                                       [:h binf.cabi/i32]]) env32-gpu)
+                                       [:h binf.cabi/i32]]) env32)
           e {:a [0 0],
              :b [0 0 0],
              :c 0,
@@ -697,7 +694,7 @@
       (let [v (alloc-view)
             column (binf.cabi/vector :ivec4 binf.cabi/i32 4 16)
             matrix (binf.cabi/vector :mat4x4 column 4 64)
-            layout (matrix env32-gpu)
+            layout (matrix env32)
             e (->> (range 16) (partition 4) (mapv vec))]
         (binf.cabi/wr-cabi v layout e)
         (binf/seek v 0)
@@ -708,7 +705,7 @@
       (let [v (alloc-view)
             column (binf.cabi/vector :ivec4 binf.cabi/i32 2 8)
             matrix (binf.cabi/vector :mat3x2 column 3 24)
-            layout (matrix env32-gpu)
+            layout (matrix env32)
             e (->> (range (* 3 2)) (partition 2) (mapv vec))]
         (binf.cabi/wr-cabi v layout e)
         (binf/seek v 0)
@@ -719,7 +716,7 @@
       (let [v (alloc-view)
             column (binf.cabi/vector :ivec4 binf.cabi/i32 3 16)
             matrix (binf.cabi/vector :mat2x3 column 2 32)
-            layout (matrix env32-gpu)
+            layout (matrix env32)
             e (->> (range (* 3 2)) (partition 3) (mapv vec))]
         (binf.cabi/wr-cabi v layout e)
         (binf/seek v 0)
@@ -744,7 +741,7 @@
                                        [:e struct-a]
                                        [:f ivec3]
                                        [:g (binf.cabi/array struct-a 3)]
-                                       [:h binf.cabi/i32]]) env32-gpu)
+                                       [:h binf.cabi/i32]]) env32)
           e {:a [0 0],
              :b [0 0 0],
              :c 0,

--- a/src/test/helins/binf/test/cabi.cljc
+++ b/src/test/helins/binf/test/cabi.cljc
@@ -8,7 +8,9 @@
   {:author "Adam Helins"}
 
   (:require [clojure.test     :as t]
-            [helins.binf.cabi :as binf.cabi])
+            [helins.binf :as binf]
+            [helins.binf.cabi :as binf.cabi]
+            [helins.binf.buffer :as binf.buffer])
   (:refer-clojure :exclude [array]))
 
 
@@ -28,7 +30,8 @@
 (def env32
      (binf.cabi/env w32))
 
-
+(def env32-gpu
+     (assoc (binf.cabi/env w32) :binf.cab/gpu? true))
 
 (def env64
      (binf.cabi/env w64))
@@ -322,3 +325,436 @@
                                                    [[:c binf.cabi/u16]
                                                     [:d binf.cabi/f64]])})
             env64))))
+
+
+;;;;;;;;;; IO
+
+
+(defn alloc-view
+  ([] (alloc-view 1024))
+  ([n-byte]
+   (binf/endian-set (binf/view (binf.buffer/alloc n-byte)) :little-endian)))
+
+(t/deftest wr-cabi
+
+  (t/testing "Single primitive"
+    (let [v (alloc-view)
+          layout (binf.cabi/i32 env32)
+          e 42]
+      (binf.cabi/wr-cabi v layout e)
+      (t/is (= 4 (binf/position v)))
+      (binf/seek v 0)
+      (t/is (= e (binf/rr-i32 v)))))
+
+  (t/testing "Simple array of specially aligned arrays"
+    (let [v (alloc-view)
+          ivec3 (binf.cabi/vector :ivec3 binf.cabi/i32 3 16)
+          array-length 5
+          layout ((binf.cabi/array ivec3 array-length) env32-gpu)
+          data (->> (range (* array-length 3))
+                    (partition 3)
+                    (mapv vec))
+          e (->> data
+                 (mapcat #(conj % 0))
+                 vec)]
+      (binf.cabi/wr-cabi v layout data)
+      (t/is (= (* array-length 4 4) (binf/position v)))
+      (binf/seek v 0)
+      (doseq [i e]
+        (t/is (= i (binf/rr-i32 v))))))
+
+  (t/testing "Matrices"
+    ;; Note column orientated
+    (t/testing "4x4"
+      (let [v (alloc-view)
+            column (binf.cabi/vector :ivec4 binf.cabi/i32 4 16)
+            matrix (binf.cabi/vector :mat4x4 column 4 64)
+            layout (matrix env32-gpu)
+            matrix (->> (range 16) (partition 4) (mapv vec))
+            e (->> matrix (mapcat identity) vec)]
+        (binf.cabi/wr-cabi v layout matrix)
+        (binf/seek v 0)
+        (doseq [i e]
+          (t/is (= i (binf/rr-i32 v))))))
+
+    (t/testing "3x2"
+      (let [v (alloc-view)
+            column (binf.cabi/vector :ivec4 binf.cabi/i32 2 8)
+            matrix (binf.cabi/vector :mat3x2 column 3 24)
+            layout (matrix env32-gpu)
+            matrix (->> (range (* 3 2)) (partition 2) (mapv vec))
+            e (->> matrix (mapcat identity) vec)]
+        (binf.cabi/wr-cabi v layout matrix)
+        (binf/seek v 0)
+        (doseq [i e]
+          (t/is (= i (binf/rr-i32 v))))))
+
+    (t/testing "2x3"
+      (let [v (alloc-view)
+            column (binf.cabi/vector :ivec4 binf.cabi/i32 3 16)
+            matrix (binf.cabi/vector :mat2x3 column 2 32)
+            layout (matrix env32-gpu)
+            matrix (->> (range (* 3 2)) (partition 3) (mapv vec))
+            e (->> matrix (mapcat #(conj % 0)) vec)]
+        (binf.cabi/wr-cabi v layout matrix)
+        (binf/seek v 0)
+        (doseq [i e]
+          (t/is (= i (binf/rr-i32 v))))))))
+
+(t/deftest io-roundtrip
+
+  (t/testing "Single primitive"
+    (let [v (alloc-view)
+          layout (binf.cabi/i32 env32-gpu)
+          e 42]
+      (binf.cabi/wr-cabi v layout e)
+      (binf/seek v 0)
+      (let [r (binf.cabi/rr-cabi v layout)]
+        (t/is (= e r)))))
+
+  (t/testing "Single enum"
+    (let [layout ((binf.cabi/enum :foo
+                                  [:a
+                                   :b
+                                   [:c 1000]
+                                   :d
+                                   [:e 42]
+                                   :f]) env32-gpu)]
+
+      (let [v (alloc-view)
+            e :a]
+        (binf.cabi/wr-cabi v layout e)
+        (binf/seek v 0)
+        (let [r (binf.cabi/rr-cabi v layout)]
+          (t/is (= e r))))
+
+      (let [v (alloc-view)
+            e :c]
+        (binf.cabi/wr-cabi v layout e)
+        (binf/seek v 0)
+        (let [r (binf.cabi/rr-cabi v layout)]
+          (t/is (= e r))))))
+
+  (t/testing "Single union"
+    (let [layout ((binf.cabi/union :foo
+                                   {:a binf.cabi/i8
+                                    :b (binf.cabi/struct :bar
+                                                         [[:c binf.cabi/u16]
+                                                          [:d binf.cabi/f64]])})
+                  env64)]
+
+      (let [v (alloc-view)
+            e {:a 42}]
+        (binf.cabi/wr-cabi v layout e)
+        (t/is (= (:binf.cabi/n-byte layout) (binf/position v)))
+        (binf/seek v 0)
+        (let [r (binf.cabi/rr-cabi v layout {:pick-union (fn [union-type data-so-far]
+                                                           :a)})]
+          (t/is (= e r))))
+
+      (let [v (alloc-view)
+            e {:b {:c 43
+                   :d 84.}}]
+        (binf.cabi/wr-cabi v layout e)
+        (t/is (= (:binf.cabi/n-byte layout) (binf/position v)))
+        (binf/seek v 0)
+        (let [r (binf.cabi/rr-cabi v layout {:pick-union (fn [union-type data-so-far]
+                                                           :b)})]
+          (t/is (= e r))))))
+
+  (t/testing "Tagged union"
+    (let [layout ((binf.cabi/struct :foobar
+                                    [[:tag (binf.cabi/enum :union [:a :b])]
+                                     [:union (binf.cabi/union :foo
+                                                              {:a binf.cabi/i8
+                                                               :b (binf.cabi/struct :bar
+                                                                                    [[:c binf.cabi/u16]
+                                                                                     [:d binf.cabi/f64]])})]])
+                  env64)]
+
+      (t/testing "Read as bytes"
+
+        (let [v (alloc-view)
+              e {:tag :a
+                 :union {:a 42}}]
+          (binf.cabi/wr-cabi v layout e)
+          (t/is (= (:binf.cabi/n-byte layout) (binf/position v)))
+          (binf/seek v 0)
+          (let [r (binf.cabi/rr-cabi v layout {:pick-union (fn [union-type data-so-far] (:tag data-so-far))})]
+            (t/is (= e r))))
+
+        (let [v (alloc-view)
+              e {:tag :b
+                 :union {:b {:c 43
+                             :d 84.}}}]
+          (binf.cabi/wr-cabi v layout e)
+          (t/is (= (:binf.cabi/n-byte layout) (binf/position v)))
+          (binf/seek v 0)
+          (let [r (binf.cabi/rr-cabi v layout {:pick-union (fn [union-type data-so-far] (:tag data-so-far))})]
+            (t/is (= e r)))))))
+
+  (t/testing "Struct including union"
+    (let [layout ((binf.cabi/struct :foobar
+                                    [[:union (binf.cabi/union :foo
+                                                              {:a binf.cabi/i8
+                                                               :b (binf.cabi/struct :bar
+                                                                                    [[:c binf.cabi/u16]
+                                                                                     [:d binf.cabi/f64]])})]
+                                     [:int binf.cabi/i32]])
+                  env64)]
+
+      (let [v (alloc-view)
+            e {:union {:a 42}
+               :int 43}]
+        (binf.cabi/wr-cabi v layout e)
+        (t/is (= (:binf.cabi/n-byte layout) (binf/position v)))
+        (binf/seek v 0)
+        (let [r (binf.cabi/rr-cabi v layout {:pick-union (fn [union-type data-so-far] :a)})]
+          (t/is (= (:binf.cabi/n-byte layout) (binf/position v)))
+          (t/is (= e r))))))
+
+  (t/testing "Simple struct"
+    (let [v (alloc-view)
+          layout ((binf.cabi/struct :my-struct
+                                    [[:a binf.cabi/i32]
+                                     [:b binf.cabi/i32]]) env32-gpu)
+          e {:a 10 :b 20}]
+      (binf.cabi/wr-cabi v layout e)
+      (binf/seek v 0)
+      (let [r (binf.cabi/rr-cabi v layout)]
+        (t/is (= e r))))
+
+    (t/testing "Missing entry when writing"
+      (let [v (alloc-view)
+            layout ((binf.cabi/struct :my-struct
+                                      [[:a binf.cabi/i32]
+                                       [:b binf.cabi/i32]]) env32-gpu)
+            data {:b 20}
+            e (assoc data :a 0)]
+        (binf.cabi/wr-cabi v layout data)
+        (binf/seek v 0)
+        (let [r (binf.cabi/rr-cabi v layout)]
+          (t/is (= e r))))))
+
+  (t/testing "Simple array"
+    (let [v (alloc-view)
+          layout ((binf.cabi/array binf.cabi/i32 5) env32-gpu)
+          e [1 2 3 4 5]]
+      (binf.cabi/wr-cabi v layout e)
+      (binf/seek v 0)
+      (let [r (binf.cabi/rr-cabi v layout)]
+        (t/is (= e r)))))
+
+  (t/testing "Simple array of structs"
+    (let [v (alloc-view)
+          inner (binf.cabi/struct :my-struct
+                                  [[:a binf.cabi/i32]
+                                   [:b binf.cabi/i32]])
+          layout ((binf.cabi/array inner 5) env32-gpu)
+          e (->> (range 10) (partition 2) (mapv (fn [[a b]] {:a a :b b})))]
+      (binf.cabi/wr-cabi v layout e)
+      (binf/seek v 0)
+      (let [r (binf.cabi/rr-cabi v layout)]
+        (t/is (= e r)))))
+
+  (t/testing "Simple array of specially aligned arrays"
+    (let [v (alloc-view)
+          ivec3 (binf.cabi/vector :ivec3 binf.cabi/i32 3 16)
+          layout ((binf.cabi/array ivec3 5) env32-gpu)
+          e (->> (range 1 8)
+                 (partition 3 1)
+                 (mapv vec))]
+      (binf.cabi/wr-cabi v layout e)
+      (binf/seek v 0)
+      (let [r (binf.cabi/rr-cabi v layout)]
+        (t/is (= e r)))))
+
+  (t/testing "Struct of specially aligned arrays"
+    (let [v (alloc-view)
+          ivec3 (binf.cabi/vector :ivec3 binf.cabi/i32 3 16)
+          layout ((binf.cabi/struct :my-struct
+                                    [[:position ivec3]
+                                     [:normal ivec3]]) env32-gpu)
+          e {:position [3 4 5]
+             :normal [10 11 12]}]
+      (binf.cabi/wr-cabi v layout e)
+      (binf/seek v 0)
+      (let [r (binf.cabi/rr-cabi v layout)]
+        (t/is (= e r))))
+
+    (let [v (alloc-view)
+          ivec3 (binf.cabi/vector :ivec3 binf.cabi/i32 3 16)
+          layout ((binf.cabi/struct :my-struct
+                                    [[:position ivec3]
+                                     [:normal ivec3]]) env32-gpu)
+          e {:position [3 4 5]
+             :normal [10 11 12]}]
+      (binf.cabi/wr-cabi v layout e)
+      (binf/seek v 0)
+      (let [r (binf.cabi/rr-cabi v layout)]
+        (t/is (= e r)))))
+
+  (t/testing "Complex structures"
+    (let [v (alloc-view)
+          ivec3 (binf.cabi/vector :ivec3 binf.cabi/i32 3 16)
+          vertex (binf.cabi/struct :vertex
+                                   [[:position ivec3]
+                                    [:normal ivec3]])
+          layout ((binf.cabi/struct :vertex
+                                    [[:count binf.cabi/i32]
+                                     [:min ivec3]
+                                     [:max ivec3]
+                                     [:vertices (binf.cabi/array vertex 2)]]) env32-gpu)
+          e {:count 2
+             :min [1 2 3]
+             :max [11 12 13]
+             :vertices [{:position [1 12 3]
+                         :normal [1 0 0]}
+                        {:position [11 2 13]
+                         :normal [0 1 0]}]}]
+      (binf.cabi/wr-cabi v layout e)
+      (t/is (= (:binf.cabi/n-byte layout) (binf/position v)))
+      (binf/seek v 0)
+      (let [r (binf.cabi/rr-cabi v layout)]
+        (t/is (= e r))))
+
+    ;; Structure follows example at https://gpuweb.github.io/gpuweb/wgsl/#structure-layout-rules
+    (let [v (alloc-view)
+          ivec2 (binf.cabi/vector :ivec3 binf.cabi/i32 2 8)
+          ivec3 (binf.cabi/vector :ivec3 binf.cabi/i32 3 16)
+          ivec4 (binf.cabi/vector :ivec3 binf.cabi/i32 4 16)
+          struct-a (binf.cabi/force-align (binf.cabi/struct :a
+                                                            [[:u binf.cabi/i32]
+                                                             [:v binf.cabi/i32]
+                                                             [:w ivec2]
+                                                             [:x binf.cabi/i32]]) 16)
+          struct-b ((binf.cabi/struct :b
+                                      [[:a ivec2]
+                                       [:b ivec3]
+                                       [:c binf.cabi/i32]
+                                       [:d binf.cabi/i32]
+                                       [:e struct-a]
+                                       [:f ivec3]
+                                       [:g (binf.cabi/array struct-a 3)]
+                                       [:h binf.cabi/i32]]) env32-gpu)
+          data {}
+          e {:a [0 0],
+             :b [0 0 0],
+             :c 0,
+             :d 0,
+             :e {:u 0, :v 0, :w [0 0], :x 0},
+             :f [0 0 0],
+             :g [{:u 0, :v 0, :w [0 0], :x 0}
+                 {:u 0, :v 0, :w [0 0], :x 0}
+                 {:u 0, :v 0, :w [0 0], :x 0}],
+             :h 0}]
+      (binf.cabi/wr-cabi v struct-b data)
+      (t/is (= (:binf.cabi/n-byte struct-b) (binf/position v)))
+      (binf/seek v 0)
+      (let [r (binf.cabi/rr-cabi v struct-b)]
+        (t/is (= e r))))
+
+    ;; Structure follows example at https://gpuweb.github.io/gpuweb/wgsl/#structure-layout-rules
+    (let [v (alloc-view)
+          ivec2 (binf.cabi/vector :ivec3 binf.cabi/i32 2 8)
+          ivec3 (binf.cabi/vector :ivec3 binf.cabi/i32 3 16)
+          ivec4 (binf.cabi/vector :ivec3 binf.cabi/i32 4 16)
+          struct-a (binf.cabi/force-align (binf.cabi/struct :a
+                                                            [[:u binf.cabi/i32]
+                                                             [:v binf.cabi/i32]
+                                                             [:w ivec2]
+                                                             [:x binf.cabi/i32]]) 16)
+          struct-b ((binf.cabi/struct :b
+                                      [[:a ivec2]
+                                       [:b ivec3]
+                                       [:c binf.cabi/i32]
+                                       [:d binf.cabi/i32]
+                                       [:e struct-a]
+                                       [:f ivec3]
+                                       [:g (binf.cabi/array struct-a 3)]
+                                       [:h binf.cabi/i32]]) env32-gpu)
+          e {:a [0 0],
+             :b [0 0 0],
+             :c 0,
+             :d 0,
+             :e {:u 0, :v 9, :w [0 0], :x 0},
+             :f [0 0 0],
+             :g [{:u 0, :v 0, :w [0 0], :x 0}
+                 {:u 0, :v 0, :w [0 0], :x 0}
+                 {:u 42, :v 0, :w [0 0], :x 0}],
+             :h 7}]
+      (binf.cabi/wr-cabi v struct-b e)
+      (t/is (= (:binf.cabi/n-byte struct-b) (binf/position v)))
+      (binf/seek v 0)
+      (let [r (binf.cabi/rr-cabi v struct-b)]
+        (t/is (= e r)))))
+
+  (t/testing "Matrices"
+
+    ;; Note column orientated
+
+    (t/testing "4x4"
+      (let [v (alloc-view)
+            column (binf.cabi/vector :ivec4 binf.cabi/i32 4 16)
+            matrix (binf.cabi/vector :mat4x4 column 4 64)
+            layout (matrix env32-gpu)
+            e (->> (range 16) (partition 4) (mapv vec))]
+        (binf.cabi/wr-cabi v layout e)
+        (binf/seek v 0)
+        (let [r (binf.cabi/rr-cabi v layout)]
+          (t/is (= e r)))))
+
+    (t/testing "3x2"
+      (let [v (alloc-view)
+            column (binf.cabi/vector :ivec4 binf.cabi/i32 2 8)
+            matrix (binf.cabi/vector :mat3x2 column 3 24)
+            layout (matrix env32-gpu)
+            e (->> (range (* 3 2)) (partition 2) (mapv vec))]
+        (binf.cabi/wr-cabi v layout e)
+        (binf/seek v 0)
+        (let [r (binf.cabi/rr-cabi v layout)]
+          (t/is (= e r)))))
+
+    (t/testing "2x3"
+      (let [v (alloc-view)
+            column (binf.cabi/vector :ivec4 binf.cabi/i32 3 16)
+            matrix (binf.cabi/vector :mat2x3 column 2 32)
+            layout (matrix env32-gpu)
+            e (->> (range (* 3 2)) (partition 3) (mapv vec))]
+        (binf.cabi/wr-cabi v layout e)
+        (binf/seek v 0)
+        (let [r (binf.cabi/rr-cabi v layout)]
+          (t/is (= e r))))))
+
+  (t/testing "Absolute functions"
+    (let [v (alloc-view)
+          ivec2 (binf.cabi/vector :ivec3 binf.cabi/i32 2 8)
+          ivec3 (binf.cabi/vector :ivec3 binf.cabi/i32 3 16)
+          ivec4 (binf.cabi/vector :ivec3 binf.cabi/i32 4 16)
+          struct-a (binf.cabi/force-align (binf.cabi/struct :a
+                                                            [[:u binf.cabi/i32]
+                                                             [:v binf.cabi/i32]
+                                                             [:w ivec2]
+                                                             [:x binf.cabi/i32]]) 16)
+          struct-b ((binf.cabi/struct :b
+                                      [[:a ivec2]
+                                       [:b ivec3]
+                                       [:c binf.cabi/i32]
+                                       [:d binf.cabi/i32]
+                                       [:e struct-a]
+                                       [:f ivec3]
+                                       [:g (binf.cabi/array struct-a 3)]
+                                       [:h binf.cabi/i32]]) env32-gpu)
+          e {:a [0 0],
+             :b [0 0 0],
+             :c 0,
+             :d 0,
+             :e {:u 0, :v 9, :w [0 0], :x 0},
+             :f [0 0 0],
+             :g [{:u 0, :v 0, :w [0 0], :x 0}
+                 {:u 0, :v 0, :w [0 0], :x 0}
+                 {:u 42, :v 0, :w [0 0], :x 0}],
+             :h 7}]
+      (binf.cabi/wa-cabi v 128 struct-b e)
+      (let [r (binf.cabi/ra-cabi v 128 struct-b)]
+        (t/is (= e r))))))


### PR DESCRIPTION
Adding functions to `helins.binf.cabi` that read/write a clojure data structure according to some layout.

## Example

```clojure
(let [v some-binf-view
      env (binf.cabi/env w32)
      layout ((binf.cabi/struct :my-struct
                                [[:a binf.cabi/i32]
                                 [:b binf.cabi/i32]]) env)
      e {:a 10 :b 20}]
  (binf.cabi/wr-cabi v layout e)
  (binf/seek v 0)
  (let [r (binf.cabi/rr-cabi v layout)]
    (t/is (= e r))))
```

## Notes

I have some code in another project that was building up layouts similarish to `helins.binf.cabi`. I thought I would look into switching over to that. I also had some functionality to read and write to memory some clojure data structure according to some layout which was not too tricky to port over.

I have done the necessary work so that it can be used for GPU friendly layouts. The main blocker there was around representing things like a vector which needs to be aligned according to its size rather than the alignment of the numbers it holds. 

So a vector of 3 x f32 has a size of 12 bytes and a desired alignment of 16 bytes. 

Thus it should look something like:

```clojure
{:binf.cabi/align 16,
 :binf.cabi/n-byte 12,
 :binf.cabi/type :array,
 :binf.cabi.array/element #:binf.cabi{:align 4, :n-byte 4, :type :f32},
 :binf.cabi.array/n-element 3}
```

This does not seem possible to produce with the existing functions in the cabi namespace. Something like `(force-align (array f32 3) 16)` just results in a `:binf.cabi/align` of 4 on the resulting layout.

I added the function `(vector type description-fn n-element stride)` to help with this. e.g. `(vector :vec3 f32 3 16)`. It just produces an array but `:binf.cabi/align` is set to `stride` and `type` just provides a touch of metadata. I think I am happy with it producing an array rather than introducing a new `:binf.cabi/type`. Then a matrix is just a vector of a vector.

Performance has not been examined. Some transients could be used here and there on the read side. For my use I have just needed to read/write small things anyway.

There is no support for read or write of pointers.

Some more thought may be put into reading unions.